### PR TITLE
Add `ReplaceFileNamesAction.getActionUpdateThread`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,12 +7,12 @@ pluginVersion = 1.2.8
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 213
+pluginSinceBuild = 222.3345.118
 pluginUntilBuild = 241.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2022.1
+platformVersion = 2022.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/kotlin/nl/bryanderidder/regexrenamefiles/ReplaceFileNamesAction.kt
+++ b/src/main/kotlin/nl/bryanderidder/regexrenamefiles/ReplaceFileNamesAction.kt
@@ -1,5 +1,6 @@
 package nl.bryanderidder.regexrenamefiles
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.application.ReadAction
@@ -17,6 +18,7 @@ import java.io.IOException
  * @author Bryan de Ridder
  */
 class ReplaceFileNamesAction : DumbAwareAction(ActionIcon) {
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(event: AnActionEvent) {
         val selectedFiles = event.getData(PlatformDataKeys.VIRTUAL_FILE_ARRAY)


### PR DESCRIPTION
Bump the minimum supported IDE version to 2022.2 release.

Fixes #34